### PR TITLE
Add fog-aws gem & configure carrierwave to use AWS for production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'basscss-rails'
 gem "haml-rails", "~> 1.0"
 gem 'material_icons'
 gem 'carrierwave'
+gem 'fog-aws'
 gem 'mini_magick'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
     docile (1.3.0)
     erubi (1.7.1)
     erubis (2.7.0)
+    excon (0.62.0)
     execjs (2.7.0)
     factory_bot (4.8.2)
       activesupport (>= 3.0.0)
@@ -89,6 +90,22 @@ GEM
     ffi (1.9.23)
     figaro (1.1.1)
       thor (~> 0.14)
+    fog-aws (2.0.1)
+      fog-core (~> 1.38)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (1.45.0)
+      builder
+      excon (~> 0.58)
+      formatador (~> 0.2)
+    fog-json (1.0.2)
+      fog-core (~> 1.0)
+      multi_json (~> 1.10)
+    fog-xml (0.1.3)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (0.2.5)
     geckodriver-helper (0.0.4)
       archive-zip (~> 0.7.0)
     globalid (0.4.1)
@@ -112,6 +129,7 @@ GEM
     i18n (1.0.0)
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
+    ipaddress (0.8.3)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -288,6 +306,7 @@ DEPENDENCIES
   database_cleaner
   factory_bot_rails
   figaro
+  fog-aws
   geckodriver-helper
   haml-rails (~> 1.0)
   jbuilder (~> 2.5)

--- a/app/uploaders/recipe_image_uploader.rb
+++ b/app/uploaders/recipe_image_uploader.rb
@@ -4,7 +4,7 @@ class RecipeImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
+  # storage :file
   # storage :fog
 
   # Override the directory where uploaded files will be stored.

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,24 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+CarrierWave.configure do |config|
+
+  if Rails.env.development? || Rails.env.test?
+    config.storage = :file
+  end
+
+  if Rails.env.production?
+    config.storage = :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_credentials = {
+      :provider               => 'AWS',
+      :aws_access_key_id      => ENV['AWS_ACCESS_KEY_ID'],
+      :aws_secret_access_key  => ENV['AWS_SECRET_ACCESS_KEY'],
+      :region                 => 'us-east-2'
+    }
+  end
+
+  config.fog_directory  = ENV['S3_BUCKET_NAME']
+
+end


### PR DESCRIPTION
* Add fog-aws gem
* Add carrierwave initializer to configure production file storage to AWS
* Keep development & test env storage in file tree